### PR TITLE
Credentials obtained automatically when run in ACR Tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,9 @@ RUN make binaries && mv bin/acr /usr/bin/acr
 FROM alpine:3.9.4
 RUN apk --update add ca-certificates
 COPY --from=acr-cli /usr/bin/acr /usr/bin/acr
-ENTRYPOINT [ "acr" ]
+RUN apk add --no-cache \
+	bash \
+	jq \
+	curl
+COPY ./acr.sh /acrscripts/acr.sh
+ENTRYPOINT [ "bash","/acrscripts/acr.sh" ]

--- a/acr.sh
+++ b/acr.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+AGO=7d
+while getopts "r:a:f:n:d" OPTION; do
+  case $OPTION in
+    r )
+      REGISTRY=$OPTARG
+      ;;
+    a ) 
+      AGO=$OPTARG
+      ;;
+    f ) 
+      FILTER=$OPTARG
+      ;;
+    n ) 
+      REPOSITORY=$OPTARG
+      ;;
+    d )
+      DANGLING=1
+      ;;
+    ? ) 
+        echo "ERR: Usage: acr.sh -r <REGISTRY> -n <REPOSITORY_NAME> -a <AGO> -f <FILTER>"
+        exit 1
+      ;;
+  esac
+done
+
+if [ -z "$REPOSITORY" ]
+   then
+      echo ERR: -r Repository not set. 
+      exit 1
+fi
+
+export ACR_REFRESH_TOKEN=$(cat ~/.docker/config.json | jq -r --arg r $REGISTRY '.auths[$r].identitytoken')
+export SCOPE="repository:*:*"
+export ACR_ACCESS_TOKEN=$(curl --silent -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=refresh_token&service=$REGISTRY&scope=$SCOPE&refresh_token=$ACR_REFRESH_TOKEN" https://$REGISTRY/oauth2/token | jq -r '.access_token')
+
+if [ -z "$ACR_ACCESS_TOKEN" ]
+    then
+        echo ERR: Unable to resolve authentication
+        exit 1
+fi
+
+if [ -z "$FILTER" ]
+  then
+    if (($DANGLING))
+      then
+          acr purge -r $REGISTRY --ago $AGO --repository $REPOSITORY --access-token $ACR_ACCESS_TOKEN --dangling
+      else
+          acr purge -r $REGISTRY --ago $AGO --repository $REPOSITORY --access-token $ACR_ACCESS_TOKEN 
+    fi
+  else
+    if (($DANGLING))
+      then
+          acr purge -r $REGISTRY --ago $AGO --filter $FILTER --repository $REPOSITORY --access-token $ACR_ACCESS_TOKEN --dangling
+      else
+          acr purge -r $REGISTRY --ago $AGO --filter $FILTER --repository $REPOSITORY --access-token $ACR_ACCESS_TOKEN 
+    fi
+fi

--- a/cmd/api/acrsdk.go
+++ b/cmd/api/acrsdk.go
@@ -20,6 +20,11 @@ const (
 	registryURL = ".azurecr.io"
 )
 
+// BearerAuth returns the authentication header in case an access token was specified.
+func BearerAuth(accessToken string) string {
+	return "Bearer " + accessToken
+}
+
 // BasicAuth returns the username and the passwrod encoded in base 64.
 func BasicAuth(username string, password string) string {
 	auth := username + ":" + password


### PR DESCRIPTION
When run inside an ACR task the container image is now able to receive the credentials from the task.

An example of a run is
az acr run --cmd "{{ .Run.Registry }}/purge:latest -r {{ .Run.Registry }} -n reponame -a 10d -f '^hello.*'" /dev/null

This would delete all tags that are older than 10 days and their names begin with hello
(Assuming the acr-cli is built as a docker image named <registry>/purge:latest in the same registry)